### PR TITLE
Use PROJECT_SOURCE_DIR variable in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,12 +29,12 @@ install(
 )
 
 install(
-    DIRECTORY ${CMAKE_SOURCE_DIR}/include/
+    DIRECTORY ${PROJECT_SOURCE_DIR}/include/
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )
 
 install(
-    DIRECTORY ${CMAKE_SOURCE_DIR}/external/aixlog/include/
+    DIRECTORY ${PROJECT_SOURCE_DIR}/external/aixlog/include/
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/external/"
 )
 


### PR DESCRIPTION
Menggunakan CMAKE_SOURCE_DIR akan menjadi masalah jika library di embed kedalam project lain, karena CMAKE_SOURCE_DIR akan menjadi root project lain tersebut.