### PR TITLE
Remove copy elision warning in gcc 9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
 
 RUN apt-get -y update && \
     apt-get -y upgrade && \

--- a/include/libasyik/http.hpp
+++ b/include/libasyik/http.hpp
@@ -1,7 +1,12 @@
 #ifndef LIBASYIK_ASYIK_HTTP_HPP
 #define LIBASYIK_ASYIK_HTTP_HPP
 
-#include "libasyik/asyik_fwd.hpp"
+#include "asyik_fwd.hpp"
+#include "common.hpp"
+#include "error.hpp"
+#include "service.hpp"
+#include "internal/asio_internal.hpp"
+
 #include <string>
 #include <regex>
 #include <any>
@@ -14,9 +19,7 @@
 #include <boost/beast/http.hpp>
 #include <boost/beast/ssl.hpp>
 #include <boost/beast/websocket.hpp>
-#include "error.hpp"
-#include "boost/algorithm/string/predicate.hpp"
-#include "internal/asio_internal.hpp"
+#include <boost/algorithm/string/predicate.hpp>
 
 namespace fibers = boost::fibers;
 using fiber = boost::fibers::fiber;

--- a/include/libasyik/internal/asio_internal.hpp
+++ b/include/libasyik/internal/asio_internal.hpp
@@ -7,7 +7,6 @@
 #include <boost/beast/http.hpp>
 #include <boost/beast/websocket.hpp>
 #include <boost/fiber/all.hpp>
-#include "libasyik/error.hpp"
 
 namespace asio = boost::asio;
 namespace fibers = boost::fibers;
@@ -41,7 +40,7 @@ namespace asyik
                             prom.set_exception(
                                 std::make_exception_ptr(network_error("read_error")));
                     });
-                return std::move(future);
+                return future;
             };
 
             template <typename... Args>
@@ -62,7 +61,7 @@ namespace asyik
                             prom.set_exception(
                                 std::make_exception_ptr(network_error("write_error")));
                     });
-                return std::move(future);
+                return future;
             };
 
             template <typename... Args>
@@ -83,7 +82,7 @@ namespace asyik
                             prom.set_exception(
                                 std::make_exception_ptr(network_error("read_error")));
                     });
-                return std::move(future);
+                return future;
             };
 
             template <typename T>
@@ -97,7 +96,7 @@ namespace asyik
                         prom.set_value();
                     });
 
-                return std::move(future);
+                return future;
             };
 
             template <typename Resolver, typename... Args>
@@ -119,7 +118,7 @@ namespace asyik
                             prom.set_exception(
                                 std::make_exception_ptr(network_error("resolve error")));
                     });
-                return std::move(future);
+                return future;
             };
 
             template <typename Conn, typename... Args>
@@ -141,7 +140,7 @@ namespace asyik
                             prom.set_exception(
                                 std::make_exception_ptr(network_error("connect error")));
                     });
-                return std::move(future);
+                return future;
             }
         } // namespace socket
 
@@ -175,7 +174,7 @@ namespace asyik
                             prom.set_exception(
                                 std::make_exception_ptr(network_error("read error")));
                     });
-                return std::move(future);
+                return future;
             };
 
             template <typename... Args>
@@ -196,7 +195,7 @@ namespace asyik
                             prom.set_exception(
                                 std::make_exception_ptr(network_error("write_error")));
                     });
-                return std::move(future);
+                return future;
             };
         } // namespace http
 
@@ -220,7 +219,7 @@ namespace asyik
                                                 network_error("handshake error")));
                                     });
 
-                return std::move(future);
+                return future;
             }
 
             template <typename Conn, typename... Args>
@@ -241,7 +240,7 @@ namespace asyik
                                                network_error("shutdown error")));
                                    });
 
-                return std::move(future);
+                return future;
             }
         } // namespace ssl
 
@@ -265,7 +264,7 @@ namespace asyik
                                        prom.set_exception(std::make_exception_ptr(
                                            network_error("read_error")));
                                });
-                return std::move(future);
+                return future;
             }
 
             template <typename Conn, typename... Args>
@@ -287,7 +286,7 @@ namespace asyik
                             prom.set_exception(
                                 std::make_exception_ptr(network_error("read_error")));
                     });
-                return std::move(future);
+                return future;
             }
 
             template <typename Conn, typename... Args>
@@ -308,7 +307,7 @@ namespace asyik
                                         prom.set_exception(std::make_exception_ptr(
                                             network_error("write error")));
                                 });
-                return std::move(future);
+                return future;
             }
 
             template <typename Conn, typename... Args>
@@ -330,7 +329,7 @@ namespace asyik
                                 std::make_exception_ptr(network_error("accept error")));
                     });
 
-                return std::move(future);
+                return future;
             }
 
             template <typename Conn, typename... Args>
@@ -352,7 +351,7 @@ namespace asyik
                                 std::make_exception_ptr(network_error("handshake error")));
                     });
 
-                return std::move(future);
+                return future;
             }
 
             template <typename Conn, typename... Args>
@@ -374,7 +373,7 @@ namespace asyik
                                 std::make_exception_ptr(network_error("close error")));
                     });
 
-                return std::move(future);
+                return future;
             }
         } // namespace websocket
     }     //namespace internal

--- a/include/libasyik/memcache.hpp
+++ b/include/libasyik/memcache.hpp
@@ -1,11 +1,13 @@
 #ifndef LIBASYIK_MEMCACHE_HPP
 #define LIBASYIK_MEMCACHE_HPP
 
-#include <memory>
-#include <boost/fiber/mutex.hpp>
+#include "libasyik/service.hpp"
 #include "common.hpp"
 #include "libasyik/asyik_fwd.hpp"
 #include "libasyik/error.hpp"
+
+#include <memory>
+#include <boost/fiber/mutex.hpp>
 
 namespace asyik
 {

--- a/include/libasyik/service.hpp
+++ b/include/libasyik/service.hpp
@@ -101,7 +101,7 @@ namespace asyik
         };
       });
 
-      return std::move(future);
+      return future;
     }
 
     void set_default_log_severity(log_severity s)
@@ -134,7 +134,7 @@ namespace asyik
         };
       });
 
-      return std::move(future);
+      return future;
     };
 
     void run();

--- a/tests/test_http.cpp
+++ b/tests/test_http.cpp
@@ -641,7 +641,7 @@ namespace asyik
             prom.set_exception(
                 std::make_exception_ptr(asyik::network_error("send error")));
         });
-    return std::move(future);
+    return future;
   }
 
   TEST_CASE("test manual handling of http requests", "[http]")
@@ -704,7 +704,7 @@ namespace asyik
       }
 
       LOG(INFO)<<"performing client requests from inside async()..\n";
-      std::atomic<int> counter = 0;
+      std::atomic<int> counter{0};
       for(int i=0;i<50;i++)
       {
         as->async([as, &counter]()

--- a/tests/test_http.cpp
+++ b/tests/test_http.cpp
@@ -1,6 +1,6 @@
-#include "catch2/catch.hpp"
-#include "libasyik/service.hpp"
 #include "libasyik/http.hpp"
+#include "libasyik/service.hpp"
+#include "catch2/catch.hpp"
 
 namespace asyik
 {

--- a/tests/test_memcache.cpp
+++ b/tests/test_memcache.cpp
@@ -1,7 +1,7 @@
-#include "catch2/catch.hpp"
+#include "libasyik/memcache.hpp"
 #include "libasyik/error.hpp"
 #include "libasyik/service.hpp"
-#include "libasyik/memcache.hpp"
+#include "catch2/catch.hpp"
 
 namespace asyik 
 {
@@ -164,7 +164,7 @@ TEST_CASE("Testing multithreading")
   auto as = asyik::make_service();
   auto cache = asyik::make_memcache_mt<int, int, 1, 50>(as);
 
-  std::atomic<int> num_done = 0;
+  std::atomic<int> num_done{0};
   for(int i=0;i<64;i++)
     as->async([cache, as, i, &num_done]()
     {


### PR DESCRIPTION
the copy elision warning is caused by usage of `std::move` in return value of function