### PR TITLE
Fix links to itself on newer version of cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ target_include_directories(${PROJECT_NAME} INTERFACE "$<BUILD_INTERFACE:${CMAKE_
 
 target_include_directories(${PROJECT_NAME} PRIVATE external/aixlog/include)
 target_include_directories(${PROJECT_NAME} INTERFACE "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/external>")
-target_link_libraries(${PROJECT_NAME} ${PROJECT_NAME})
 
 install(
   TARGETS ${PROJECT_NAME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ RUN apt-get -y update && \
     apt-get -y autoremove && \
     apt-get install -y build-essential gdb wget git libssl-dev && \
     mkdir ~/temp && cd ~/temp && \
-    wget  https://cmake.org/files/v3.14/cmake-3.14.5.tar.gz && \
-    tar -zxvf cmake-3.14.5.tar.gz && \
-    cd cmake-3.14.5 && \
+    wget https://github.com/Kitware/CMake/releases/download/v3.21.4/cmake-3.21.4.tar.gz && \
+    tar -zxvf cmake-3.21.4.tar.gz && \
+    cd cmake-3.21.4 && \
     ./bootstrap && make -j4 && make install && \
     rm -rf ~/temp/* && \
     cd ~/temp &&  wget https://sourceforge.net/projects/boost/files/boost/1.73.0/boost_1_73_0.tar.gz && \


### PR DESCRIPTION
fix error `target links to itself` when building with newer version of cmake (3.21.4)