### PR TITLE
Support cxx 11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,11 @@
 cmake_minimum_required(VERSION 3.14)
 project(libasyik)
 
-add_subdirectory(src)
+SET(CMAKE_CXX_STANDARD 11)
+
 add_subdirectory(tests)
 add_subdirectory(external/Catch2)
+add_subdirectory(src)
 
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
                                                   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 project(libasyik)
 
-set(CMAKE_CXX_STANDARD 17)
-SET(GCC_COVERAGE_COMPILE_FLAGS "-g -O0 -coverage -fprofile-arcs -ftest-coverage")
-SET(GCC_COVERAGE_LINK_FLAGS    "-coverage -lgcov")
-SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -Werror=return-type -Wno-unused-variable")
-SET(CMAKE_CXX_FLAGS_DEBUG  "${CMAKE_CXX_FLAGS_DEBUG} ${GCC_COVERAGE_COMPILE_FLAGS}" )
-SET(CMAKE_EXE_LINKER_FLAGS_DEBUG  "${CMAKE_EXE_LINKER_FLAGS_DEBUG} ${GCC_COVERAGE_LINK_FLAGS}" )
-
-
 add_subdirectory(src)
 add_subdirectory(tests)
 add_subdirectory(external/Catch2)

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get -y update && \
     ./bootstrap && make -j4 && make install && \
     rm -rf ~/temp/* && \
     cd ~/temp &&  wget https://sourceforge.net/projects/boost/files/boost/1.73.0/boost_1_73_0.tar.gz && \
-    tar -zxvf boost_1_73_0.tar.gz && cd boost_1_73_0 && ./bootstrap.sh && ./b2 cxxflags="-std=c++17" --reconfigure --with-fiber --with-date_time install && \
+    tar -zxvf boost_1_73_0.tar.gz && cd boost_1_73_0 && ./bootstrap.sh && ./b2 cxxflags="-std=c++14" --reconfigure --with-fiber --with-date_time install && \
     cd ~/temp && git clone https://github.com/linux-test-project/lcov.git && cd lcov && make install && cd .. && \
     apt-get install -y libperlio-gzip-perl libjson-perl && \
     rm -rf ~/temp/* && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get -y update && \
     ./bootstrap && make -j4 && make install && \
     rm -rf ~/temp/* && \
     cd ~/temp &&  wget https://sourceforge.net/projects/boost/files/boost/1.73.0/boost_1_73_0.tar.gz && \
-    tar -zxvf boost_1_73_0.tar.gz && cd boost_1_73_0 && ./bootstrap.sh && ./b2 cxxflags="-std=c++14" --reconfigure --with-fiber --with-date_time install && \
+    tar -zxvf boost_1_73_0.tar.gz && cd boost_1_73_0 && ./bootstrap.sh && ./b2 cxxflags="-std=c++11" --reconfigure --with-fiber --with-date_time install && \
     cd ~/temp && git clone https://github.com/linux-test-project/lcov.git && cd lcov && make install && cd .. && \
     apt-get install -y libperlio-gzip-perl libjson-perl && \
     rm -rf ~/temp/* && \

--- a/README.md
+++ b/README.md
@@ -92,6 +92,17 @@ void main()
 }
 ```
 
+If you're using C++11 that does not support auto in lambda:
+```c++
+using namespace asyik;
+
+server->on_websocket("/websocket", [](websocket_ptr ws, const http_route_args& args) 
+{ };
+
+server->on_http_request("/name/<string>", "GET", [](http_request_ptr req, const http_route_args& args)
+{ };
+```
+
 #### SQL Database
 ```c++
 #include "libasyik/sql.hpp"
@@ -130,7 +141,7 @@ void some_handler(asyik::service_ptr as)
 
 ### Requirements
 
- - C++ compiler with good C++17 support (tested with GCC 7.5.0)
+ - C++ compiler with >=C++11 support (C++14 or C++17 is recommended, tested with GCC 7.5.0)
  - Boost library with Boost::context, Boost::fiber, and Boost::asio(Boost version 1.70.0 or above recommended)
  - CMake > 3.12
  - SOCI with SQLite and PostgreSQL backend and required low level libraries
@@ -156,7 +167,7 @@ As example use following CMakeLists.txt template to invoke Libasyik using **find
 ```
 cmake_minimum_required(VERSION 3.14)
 project(test_asyik)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 11)  #set to 14 or 17 when available
 
 add_executable(${PROJECT_NAME} test.cpp) # add more source code here
 

--- a/include/libasyik/http.hpp
+++ b/include/libasyik/http.hpp
@@ -3,6 +3,7 @@
 
 #include <any>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/any.hpp>
 #include <boost/asio/ssl/error.hpp>
 #include <boost/asio/ssl/stream.hpp>
 #include <boost/beast/core.hpp>
@@ -158,7 +159,7 @@ class http_server
   http_connection_ptr<stream_type> get_request_connection(const Req& req)
   {
     auto p =
-        std::any_cast<http_connection_wptr<stream_type>>(req.connection_wptr);
+        boost::any_cast<http_connection_wptr<stream_type>>(req.connection_wptr);
     if (auto connection = p.lock()) {
       return connection;
     }
@@ -357,7 +358,7 @@ class http_request : public std::enable_shared_from_this<http_request> {
  private:
   boost::beast::flat_buffer buffer;
   bool manual_response;
-  std::any connection_wptr;
+  boost::any connection_wptr;
 
   template <typename StreamType>
   friend class http_server;

--- a/include/libasyik/http.hpp
+++ b/include/libasyik/http.hpp
@@ -458,7 +458,7 @@ class websocket_impl : public websocket {
   virtual size_t read_basic_buffer(std::vector<uint8_t>& b)
   {
     // auto buffer = asio::dynamic_buffer(b);
-    asio::mutable_buffer_1 mb(b.data(), b.size());
+    asio::mutable_buffers_1 mb(b.data(), b.size());
     auto buffer = beast::buffers_adaptor<asio::mutable_buffers_1>(mb);
 
     return internal::websocket::async_read(*ws, buffer).get();

--- a/include/libasyik/http.hpp
+++ b/include/libasyik/http.hpp
@@ -190,9 +190,7 @@ class http_server
                           std::string s{req.target()};
                           if (std::regex_search(s, m, std::get<1>(tuple))) {
                             a.clear();
-                            std::for_each(m.begin(), m.end(), [&a](auto item) {
-                              a.push_back(item.str());
-                            });
+                            for (const auto& item : m) a.push_back(item.str());
                             return true;
                           } else
                             return false;
@@ -326,6 +324,7 @@ class http_request : public std::enable_shared_from_this<http_request> {
 
   template <typename S>
   inline auto get_connection_handle(S server)
+      -> decltype(server->get_request_connection(*this))
   {
     return server->get_request_connection(*this);
   }
@@ -524,9 +523,7 @@ http_request_ptr http_easy_request(
     req->headers.set("Content-Type", "text/html");
 
     // user-overidden headers
-    std::for_each(headers.cbegin(), headers.cend(), [&req](const auto& item) {
-      req->headers.set(item.first, item.second);
-    });
+    for (const auto& item : headers) req->headers.set(item.first, item.second);
 
     req->body = std::forward<D>(data);
     req->method(method);

--- a/include/libasyik/http.hpp
+++ b/include/libasyik/http.hpp
@@ -457,8 +457,8 @@ class websocket_impl : public websocket {
   virtual size_t read_basic_buffer(std::vector<uint8_t>& b)
   {
     // auto buffer = asio::dynamic_buffer(b);
-    asio::mutable_buffer mb(b.data(), b.size());
-    auto buffer = beast::buffers_adaptor(mb);
+    asio::mutable_buffer_1 mb(b.data(), b.size());
+    auto buffer = beast::buffers_adaptor<asio::mutable_buffers_1>(mb);
 
     return internal::websocket::async_read(*ws, buffer).get();
   }

--- a/include/libasyik/internal/asio_internal.hpp
+++ b/include/libasyik/internal/asio_internal.hpp
@@ -19,7 +19,7 @@ namespace asyik {
 namespace internal {
 namespace socket {
 template <typename... Args>
-auto async_read(Args&&... args)
+auto async_read(Args&&... args) -> boost::fibers::future<size_t>
 {
   boost::fibers::promise<size_t> promise;
   auto future = promise.get_future();
@@ -41,7 +41,7 @@ auto async_read(Args&&... args)
 };
 
 template <typename... Args>
-auto async_write(Args&&... args)
+auto async_write(Args&&... args) -> boost::fibers::future<size_t>
 {
   boost::fibers::promise<size_t> promise;
   auto future = promise.get_future();
@@ -63,7 +63,7 @@ auto async_write(Args&&... args)
 };
 
 template <typename... Args>
-auto async_read_until(Args&&... args)
+auto async_read_until(Args&&... args) -> boost::fibers::future<size_t>
 {
   boost::fibers::promise<size_t> promise;
   auto future = promise.get_future();
@@ -85,7 +85,7 @@ auto async_read_until(Args&&... args)
 };
 
 template <typename T>
-auto async_timer_wait(T&& p)
+auto async_timer_wait(T&& p) -> boost::fibers::future<void>
 {
   boost::fibers::promise<void> promise;
   auto future = promise.get_future();
@@ -100,6 +100,7 @@ auto async_timer_wait(T&& p)
 
 template <typename Resolver, typename... Args>
 auto async_resolve(Resolver& res, Args&&... args)
+    -> boost::fibers::future<tcp::resolver::results_type>
 {
   boost::fibers::promise<tcp::resolver::results_type> promise;
   auto future = promise.get_future();
@@ -123,6 +124,7 @@ auto async_resolve(Resolver& res, Args&&... args)
 
 template <typename Conn, typename... Args>
 auto async_connect(Conn& con, Args&&... args)
+    -> boost::fibers::future<tcp::resolver::results_type::endpoint_type>
 {
   boost::fibers::promise<tcp::resolver::results_type::endpoint_type> promise;
   auto future = promise.get_future();
@@ -148,7 +150,7 @@ auto async_connect(Conn& con, Args&&... args)
 
 namespace http {
 template <typename... Args>
-auto async_read(Args&&... args)
+auto async_read(Args&&... args) -> boost::fibers::future<size_t>
 {
   boost::fibers::promise<size_t> promise;
   auto future = promise.get_future();
@@ -176,7 +178,7 @@ auto async_read(Args&&... args)
 };
 
 template <typename... Args>
-auto async_write(Args&&... args)
+auto async_write(Args&&... args) -> boost::fibers::future<size_t>
 {
   boost::fibers::promise<size_t> promise;
   auto future = promise.get_future();
@@ -200,7 +202,7 @@ auto async_write(Args&&... args)
 
 namespace ssl {
 template <typename Conn, typename... Args>
-auto async_handshake(Conn& con, Args&&... args)
+auto async_handshake(Conn& con, Args&&... args) -> boost::fibers::future<void>
 {
   boost::fibers::promise<void> promise;
   auto future = promise.get_future();
@@ -223,7 +225,7 @@ auto async_handshake(Conn& con, Args&&... args)
 }
 
 template <typename Conn, typename... Args>
-auto async_shutdown(Conn& con, Args&&... args)
+auto async_shutdown(Conn& con, Args&&... args) -> boost::fibers::future<void>
 {
   boost::fibers::promise<void> promise;
   auto future = promise.get_future();
@@ -248,7 +250,7 @@ auto async_shutdown(Conn& con, Args&&... args)
 
 namespace websocket {
 template <typename Conn, typename... Args>
-auto async_read(Conn& con, Args&&... args)
+auto async_read(Conn& con, Args&&... args) -> boost::fibers::future<size_t>
 {
   boost::fibers::promise<size_t> promise;
   auto future = promise.get_future();
@@ -271,7 +273,7 @@ auto async_read(Conn& con, Args&&... args)
 }
 
 template <typename Conn, typename... Args>
-auto async_read_some(Conn& con, Args&&... args)
+auto async_read_some(Conn& con, Args&&... args) -> boost::fibers::future<size_t>
 {
   boost::fibers::promise<size_t> promise;
   auto future = promise.get_future();
@@ -294,7 +296,7 @@ auto async_read_some(Conn& con, Args&&... args)
 }
 
 template <typename Conn, typename... Args>
-auto async_write(Conn& con, Args&&... args)
+auto async_write(Conn& con, Args&&... args) -> boost::fibers::future<size_t>
 {
   boost::fibers::promise<size_t> promise;
   auto future = promise.get_future();
@@ -317,7 +319,7 @@ auto async_write(Conn& con, Args&&... args)
 }
 
 template <typename Conn, typename... Args>
-auto async_accept(Conn& con, Args&&... args)
+auto async_accept(Conn& con, Args&&... args) -> boost::fibers::future<void>
 {
   boost::fibers::promise<void> promise;
   auto future = promise.get_future();
@@ -340,7 +342,7 @@ auto async_accept(Conn& con, Args&&... args)
 }
 
 template <typename Conn, typename... Args>
-auto async_handshake(Conn& con, Args&&... args)
+auto async_handshake(Conn& con, Args&&... args) -> boost::fibers::future<void>
 {
   boost::fibers::promise<void> promise;
   auto future = promise.get_future();
@@ -363,7 +365,7 @@ auto async_handshake(Conn& con, Args&&... args)
 }
 
 template <typename Conn, typename... Args>
-auto async_close(Conn& con, Args&&... args)
+auto async_close(Conn& con, Args&&... args) -> boost::fibers::future<void>
 {
   boost::fibers::promise<void> promise;
   auto future = promise.get_future();

--- a/include/libasyik/sql.hpp
+++ b/include/libasyik/sql.hpp
@@ -60,8 +60,9 @@ sql_pool_ptr make_sql_pool(F&& factory, C&& connectString, size_t num_pool)
 
   for (size_t i = 0; i < num_pool; i++) {
     std::lock_guard<fibers::mutex> l(p->mtx_);
-    auto s = std::make_unique<soci::session>(std::forward<F>(factory),
-                                             std::forward<C>(connectString));
+
+    std::unique_ptr<soci::session> s(new soci::session(
+        std::forward<F>(factory), std::forward<C>(connectString)));
     p->soci_sessions.push_back(std::move(s));
   };
 
@@ -90,8 +91,9 @@ sql_pool_ptr make_sql_pool(F&& factory, C&& connectString, size_t num_pool)
               try {
                 LOG(WARNING) << "health check failed: " << e.what()
                              << "\nrenew SOCI session...\n";
-                auto s = std::make_unique<soci::session>(std::forward<F>(f),
-                                                         connectString);
+
+                std::unique_ptr<soci::session> s(
+                    new soci::session(std::forward<F>(f), connectString));
                 l.lock();
                 p->soci_sessions.push_back(std::move(s));
               } catch (std::exception& e) {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
 
-set(CMAKE_CXX_STANDARD 17)
-
 add_library(${PROJECT_NAME} service.cpp http.cpp sql.cpp)
 
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,12 @@
 cmake_minimum_required(VERSION 3.14)
 project(libasyik_test)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 14)
+SET(GCC_COVERAGE_COMPILE_FLAGS "-g -O0 -coverage -fprofile-arcs -ftest-coverage")
+SET(GCC_COVERAGE_LINK_FLAGS    "-coverage -lgcov")
+SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -Werror=return-type -Wno-unused-variable")
+SET(CMAKE_CXX_FLAGS_DEBUG  "${CMAKE_CXX_FLAGS_DEBUG} ${GCC_COVERAGE_COMPILE_FLAGS}" )
+SET(CMAKE_EXE_LINKER_FLAGS_DEBUG  "${CMAKE_EXE_LINKER_FLAGS_DEBUG} ${GCC_COVERAGE_LINK_FLAGS}" )
 
 add_executable(${PROJECT_NAME} test.cpp test_http.cpp test_service.cpp test_sql.cpp test_memcache.cpp test_rate_limit.cpp)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 project(libasyik_test)
 
-set(CMAKE_CXX_STANDARD 14)
 SET(GCC_COVERAGE_COMPILE_FLAGS "-g -O0 -coverage -fprofile-arcs -ftest-coverage")
 SET(GCC_COVERAGE_LINK_FLAGS    "-coverage -lgcov")
 SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -Werror=return-type -Wno-unused-variable")

--- a/tests/test_memcache.cpp
+++ b/tests/test_memcache.cpp
@@ -69,11 +69,13 @@ TEST_CASE("Testing basic of memcache")
   // try creating memcache for movable only items
   auto cache2 =
       asyik::make_memcache<std::string, std::unique_ptr<std::string>, 1>(as);
-  cache2->put("1", std::move(std::make_unique<std::string>("test")));
+  cache2->put("1",
+              std::move(std::unique_ptr<std::string>(new std::string("test"))));
   LOG(INFO) << "test priontout cache2:" << *(cache2->at("1")) << "\n";
   REQUIRE(!strcmp("test", cache2->at("1")->c_str()));
   asyik::sleep_for(std::chrono::milliseconds(500));
-  cache2->put("1", std::move(std::make_unique<std::string>("test2")));
+  cache2->put(
+      "1", std::move(std::unique_ptr<std::string>(new std::string("test2"))));
   LOG(INFO) << "test priontout cache2:" << *(cache2->at("1")) << "\n";
   REQUIRE(!strcmp("test2", cache2->get("1")->c_str()));
   LOG(INFO) << "test priontout cache2:" << *(cache2->at("1")) << "\n";

--- a/tests/test_service.cpp
+++ b/tests/test_service.cpp
@@ -164,12 +164,21 @@ TEST_CASE("execute async", "[service]")
         },
         10)
       .get();
+#if __cplusplus >= 201402L
   as->async(
       [](auto& i) -> void {
         usleep(0);
         i++;
       },
       i);
+#else
+  as->async(
+      [](std::atomic<int>& i) -> void {
+        usleep(0);
+        i++;
+      },
+      i);
+#endif
   as->async(
         [&i](string_view s, const std::string s2) -> void {
           usleep(130);


### PR DESCRIPTION
Add ability for libasyik to be compiled with c++11 header support. This library still used c++14 features as extension hence still requiring GCC 6.0 or above